### PR TITLE
Allow string content in Metaschema property values

### DIFF
--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -799,7 +799,7 @@
         <define-flag name="namespace" as-type="uri" default="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
             <formal-name>Property Namespace</formal-name>
         </define-flag>
-        <define-flag name="value" as-type="token" required="yes">
+        <define-flag name="value" as-type="string" required="yes">
             <formal-name>Property Value</formal-name>
         </define-flag>
     </define-assembly>

--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -164,7 +164,7 @@
     <xs:attribute name="namespace" type="URIDatatype"
       default="http://csrc.nist.gov/ns/oscal/metaschema/1.0"/>
     <xs:attribute name="name" type="TokenDatatype" use="required"/>
-    <xs:attribute name="value" type="TokenDatatype" use="required"/>
+    <xs:attribute name="value" type="StringDatatype" use="required"/>
   </xs:complexType>
 
   <xs:simpleType name="ModelNameType">


### PR DESCRIPTION
# Committer Notes

This PR relaxes the data type used for property values to allow different types of string values, including URIs, URLs, markdown, values that contain colons, etc.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
