### PR TITLE
Add `collapsible` to `GlobalFieldDefinitionType` type in XSD

### DIFF
--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -313,6 +313,7 @@
       <xs:element name="example" type="ExampleType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attributeGroup ref="FieldValueAttributeGroup"/>
+    <xs:attribute name="collapsible" type="YesNoType" default="no"/>
     <xs:attributeGroup ref="DefinitionNamingGroup"/>
     <xs:attribute name="scope" type="ScopeType" default="global"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>


### PR DESCRIPTION
# Committer Notes

Fixes #36.

This is ported from https://github.com/usnistgov/metaschema/pull/775.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
