### PR TITLE
Update Metaschema module for all non-`expect` constraints to support `message`

### DIFF
--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -1042,6 +1042,7 @@
             <field ref="constraint-value-enum" min-occurs="1" max-occurs="unbounded">
                 <group-as name="enums" in-json="ARRAY"/>
             </field>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>
     </define-assembly>
@@ -1099,6 +1100,7 @@
             <assembly ref="property" max-occurs="unbounded">
                 <group-as name="props" in-json="ARRAY"/>
             </assembly>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>
     </define-assembly>
@@ -1152,6 +1154,7 @@
                 <use-name>key-field</use-name>
                 <group-as name="key-fields" in-json="ARRAY"/>
             </assembly>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>        
     </define-assembly>
@@ -1191,6 +1194,7 @@
                 <use-name>key-field</use-name>
                 <group-as name="key-fields" in-json="ARRAY"/>
             </assembly>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>        
     </define-assembly>
@@ -1213,6 +1217,7 @@
                 <use-name>key-field</use-name>
                 <group-as name="key-fields" in-json="ARRAY"/>
             </assembly>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>        
     </define-assembly>

--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -936,6 +936,7 @@
             <field ref="constraint-value-enum" min-occurs="1" max-occurs="unbounded">
                 <group-as name="enums" in-json="ARRAY"/>
             </field>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>
     </define-assembly>
@@ -977,6 +978,7 @@
                 <use-name>key-field</use-name>
                 <group-as name="key-fields" in-json="ARRAY"/>
             </assembly>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>        
     </define-assembly>
@@ -1316,6 +1318,7 @@
                             </model>
                         </define-assembly>
                     </choice-group>
+                    <field ref="constraint-message"/>
                     <field ref="remarks"/>
                 </model>
             </define-assembly>

--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -955,7 +955,7 @@
             <assembly ref="property" max-occurs="unbounded">
                 <group-as name="props" in-json="ARRAY"/>
             </assembly>
-            <field ref="expect-constraint-message"/>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>
     </define-assembly>
@@ -1124,13 +1124,13 @@
             <assembly ref="property" max-occurs="unbounded">
                 <group-as name="props" in-json="ARRAY"/>
             </assembly>
-            <field ref="expect-constraint-message"/>
+            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>
     </define-assembly>
     
-    <define-field name="expect-constraint-message">
-        <formal-name>Expect Condition Violation Message</formal-name>
+    <define-field name="constraint-message">
+        <formal-name>Constraint Condition Violation Message</formal-name>
         <use-name>message</use-name>
     </define-field>
 


### PR DESCRIPTION
# Committer Notes

This PR does not close, but is part of, #34.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~ Follow on in another PR for website changes tracked in issue #34.
