### PR TITLE
Remove custom messages from allowed-values constraints

### DIFF
--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -936,7 +936,6 @@
             <field ref="constraint-value-enum" min-occurs="1" max-occurs="unbounded">
                 <group-as name="enums" in-json="ARRAY"/>
             </field>
-            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>
     </define-assembly>
@@ -1045,7 +1044,6 @@
             <field ref="constraint-value-enum" min-occurs="1" max-occurs="unbounded">
                 <group-as name="enums" in-json="ARRAY"/>
             </field>
-            <field ref="constraint-message"/>
             <field ref="remarks"/>
         </model>
     </define-assembly>

--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -918,7 +918,6 @@
       <xs:extension base="ConstraintType">
         <xs:sequence>
           <xs:element name="enum" type="AllowedValueType" minOccurs="1" maxOccurs="unbounded"/>
-          <xs:element name="message" type="StringDatatype" minOccurs="0"/>
           <xs:group ref="ConstraintContentsGroup"/>
         </xs:sequence>
         <xs:attribute name="allow-other" type="YesNoType" default="no">


### PR DESCRIPTION
# Committer Notes

Removed custom message support from allowed-values constraints previously added in #40 and #42, since these verifying these constraints apply multiple constraints at the same time. This makes using a constraint-specific message unusable.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
