### PR TITLE
Constraint to error on check `group-as/@in-json` with parent `@max-occurs`

### DIFF
--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -46,10 +46,10 @@
                 <description>Ensure each import is a Metaschema module.</description>
                 <message>Unable the resource at '{{ resolve-uri(@href) }}' is not a Metaschema module.</message>
             </expect>
-            <expect id="module-model-group-as-in-json-invalid" target=".//(define-assembly|define-field|assembly|field)[@max-occurs=1]" test=".[not(group-as)]">
-                <formal-name>Group-As Behavior Used with Valid Max-Occurs</formal-name>
-                <description>Given group-as behavior for a parent assembly or field, you cannot have a group-as for multiple values.</description>
-                <message>The group-as for the parent location requires a max-occurs that is greater than 1 to support that feature.</message>
+            <expect id="module-model-group-a-invalid" target=".//(define-assembly|define-field|assembly|field)[@max-occurs=1]" test=".[not(group-as)]">
+                <formal-name>Group-As unneeded with max-occurs='1'</formal-name>
+                <description>A field or assembly instance with a max occurrence of `1` must not have a `group-as` child.</description>
+                <message>Use of `group-as` in the location '{{ path() }}' requires a parent with a max-occurs that is greater than 1; otherwise the `group-as` needs to be removed.</message>
             </expect>
         </constraints>
     </context>

--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -46,6 +46,11 @@
                 <description>Ensure each import is a Metaschema module.</description>
                 <message>Unable the resource at '{{ resolve-uri(@href) }}' is not a Metaschema module.</message>
             </expect>
+            <expect id="module-model-group-as-in-json-invalid" target=".//(define-assembly|define-field|assembly|field)[@max-occurs=1]" test=".[not(group-as)]">
+                <formal-name>Group-As Behavior Used with Valid Max-Occurs</formal-name>
+                <description>Given group-as behavior for a parent assembly or field, you cannot have a group-as for multiple values.</description>
+                <message>The group-as for the parent location requires a max-occurs that is greater than 1 to support that feature.</message>
+            </expect>
         </constraints>
     </context>
     <context>


### PR DESCRIPTION
# Committer Notes

This new constraint implements a check for the following issue comment.

https://github.com/metaschema-framework/metaschema-java/issues/221#issuecomment-2442802840

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
