### PR TITLE
Prepare version tagging for release 1.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metaschema-framework-website",
-    "version": "1.0.0",
+    "version": "1.0.0-rc.1",
     "devDependencies": {
         "@fullhuman/postcss-purgecss": "^7.0.2",
         "ajv-cli": "^5.0.x",

--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -3,7 +3,7 @@
  xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../xml/metaschema.xsd"
  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
     <schema-name>Metaschema Model</schema-name>
-    <schema-version>1.0.0-M2</schema-version>
+    <schema-version>1.0.0-rc.1</schema-version>
     <short-name>metaschema-model</short-name>
     <namespace>http://csrc.nist.gov/ns/oscal/metaschema/1.0</namespace>
     <json-base-uri>http://csrc.nist.gov/ns/oscal/metaschema/1.0</json-base-uri>


### PR DESCRIPTION
## Summary

- Bumps version to `1.0.0-rc.1` in preparation for the first release candidate
- Updates `package.json` version from `1.0.0` to `1.0.0-rc.1`
- Updates `schema/metaschema/metaschema-module-metaschema.xml` schema-version from `1.0.0-M2` to `1.0.0-rc.1`

## Background

This is the first release candidate for Metaschema 1.0.0, following the project relocation from [usnistgov/metaschema](https://github.com/usnistgov/metaschema) (last release: v0.10.0) to [metaschema-framework/metaschema](https://github.com/metaschema-framework/metaschema).

## Test plan

- [x] Verify version numbers are correctly updated
- [x] Ensure CI/CD pipelines pass
- [x] Validate schema generation works with updated version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project version updated to 1.0.0-rc.1 to mark release candidate status.
  * Internal metadata/schema version aligned to the same release-candidate version (no functional or behavioral changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->