### PR TITLE
Add QName datatype definition and documentation

### DIFF
--- a/schema/json/metaschema-datatypes.json
+++ b/schema/json/metaschema-datatypes.json
@@ -112,6 +112,16 @@
         }
       ]
     },
+    "QNameDatatype": {
+      "description": "A qualified name as defined by XML Schema Part 2: Datatypes Second Edition, consisting of an optional namespace prefix and a local name separated by a colon.",
+      "allOf": [
+        {"$ref": "#/definitions/StringDatatype"},
+        {
+          "type": "string",
+          "pattern": "^((\\p{L}|_)(\\p{L}|\\p{N}|[.\\-_])*:)?(\\p{L}|_)(\\p{L}|\\p{N}|[.\\-_])*$"
+        }
+      ]
+    },
     "StringDatatype": {
       "description": "A non-empty string with leading and trailing whitespace disallowed. Whitespace is: U+9, U+10, U+32 or [ \n\t]+",
       "type": "string",

--- a/schema/xml/metaschema-datatypes.xsd
+++ b/schema/xml/metaschema-datatypes.xsd
@@ -170,7 +170,23 @@
 			</xs:pattern>
 		</xs:restriction>
 	</xs:simpleType>
-	
+
+	<xs:simpleType name="QNameDatatype">
+		<xs:annotation>
+			<xs:documentation>A qualified name as defined by XML Schema Part 2: Datatypes Second Edition
+				(https://www.w3.org/TR/xmlschema11-2/#QName), consisting of an optional namespace prefix
+				and a local name separated by a colon.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="StringDatatype">
+			<xs:pattern value="((\p{L}|_)(\p{L}|\p{N}|[.\-_])*:)?(\p{L}|_)(\p{L}|\p{N}|[.\-_])*">
+				<xs:annotation>
+					<xs:documentation>An optional NCName prefix followed by a colon, then an NCName
+						local part.</xs:documentation>
+				</xs:annotation>
+			</xs:pattern>
+		</xs:restriction>
+	</xs:simpleType>
+
 	<xs:simpleType name="StringDatatype">
 		<xs:annotation>
 			<xs:documentation>A non-empty string of Unicode characters with leading and trailing whitespace

--- a/website/content/specification/datatypes.md
+++ b/website/content/specification/datatypes.md
@@ -72,7 +72,7 @@ These data types represent the basic data primitives used in Metaschema to suppo
 - **numeric values:** [decimal](#decimal), [integer](#integer), [non-negative-integer](#non-negative-integer), [positive-integer](#positive-integer)
 - **temporal values:** [date](#date), [date-with-timezone](#date-with-timezone), [date-time](#date-time), [date-time-with-timezone](#date-time-with-timezone), [day-time-duration](#day-time-duration), [year-month-duration](#year-month-duration)
 - **binary values:** [base64](#base64), [boolean](#boolean)
-- **character-based values:** [email-address](#email-address), [hostname](#hostname), [ip-v4-address](#ip-v4-address), [ip-v6-address](#ip-v6-address), [string](#string), [token](#token), [uri](#uri), [uri-reference](#uri-reference), [uuid](#uuid)
+- **character-based values:** [email-address](#email-address), [hostname](#hostname), [ip-v4-address](#ip-v4-address), [ip-v6-address](#ip-v6-address), [qname](#qname), [string](#string), [token](#token), [uri](#uri), [uri-reference](#uri-reference), [uuid](#uuid)
 
 Details of these data types follow.
 
@@ -524,6 +524,57 @@ In JSON Schema, this is represented as:
     {
       "type": "integer",
       "minimum": 1
+    }
+  ]
+}
+```
+
+### qname
+
+A qualified name (QName) as defined by [XML Schema Part 2: Datatypes Second Edition](https://www.w3.org/TR/xmlschema11-2/#QName) and the [Namespaces in XML](https://www.w3.org/TR/xml-names/) specification.
+
+A QName consists of an optional namespace prefix and a local name, separated by a colon. Both the prefix and the local name are [NCNames](https://www.w3.org/TR/xmlschema11-2/#NCName) (non-colonized names).
+
+The syntax is:
+
+```
+QName ::= PrefixedName | UnprefixedName
+PrefixedName ::= Prefix ':' LocalPart
+UnprefixedName ::= LocalPart
+Prefix ::= NCName
+LocalPart ::= NCName
+```
+
+For example:
+
+```
+xs:string
+oscal:catalog
+localName
+_underscore-prefix:local_name
+```
+
+The namespace prefix is used to associate the qualified name with a namespace URI through a namespace declaration in scope. The interpretation of a QName is context-dependent, as the prefix must be resolved to a namespace URI using the applicable namespace bindings.
+
+In XML Schema this is represented as a restriction on [StringDatatype](#string) as follows:
+
+```XML
+<xs:simpleType name="QNameDatatype">
+  <xs:restriction base="StringDatatype">
+    <xs:pattern value="((\p{L}|_)(\p{L}|\p{N}|[.\-_])*:)?(\p{L}|_)(\p{L}|\p{N}|[.\-_])*"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "allOf": [
+    {"$ref": "#/definitions/StringDatatype"},
+    {
+      "type": "string",
+      "pattern": "^((\\p{L}|_)(\\p{L}|\\p{N}|[.\\-_])*:)?(\\p{L}|_)(\\p{L}|\\p{N}|[.\\-_])*$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a new QName (qualified name) datatype as defined by XML Schema Part 2: Datatypes Second Edition and the Namespaces in XML specification.

## Description

A QName consists of an optional namespace prefix and a local name separated by a colon, where both components are NCNames (non-colonized names). The syntax is:

```
QName ::= PrefixedName | UnprefixedName
PrefixedName ::= Prefix ':' LocalPart
UnprefixedName ::= LocalPart
```

## Changes

- Added `QNameDatatype` to JSON schema with pattern validation
- Added `QNameDatatype` to XML schema with pattern validation  
- Added comprehensive documentation to `datatypes.md` including:
  - Formal syntax definition
  - Examples of valid QNames
  - Explanation of context-dependent namespace resolution
  - XML and JSON schema representations
- Updated simple data types list to include qname

## Follow-up

Issue #139 tracks updating the Metapath vs XPath comparison documentation (PR #132) to include QName information once both PRs are merged.

## Test plan

- [x] Verify JSON schema is valid
- [x] Verify XML schema is valid
- [x] Verify website builds successfully
- [x] Review documentation for accuracy

Resolves #90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QName (qualified name) datatype support, enforcing XML Schema–style qualified-name syntax (optional namespace prefix plus local name).

* **Documentation**
  * Added qname section to the specification with syntax, examples, formal grammar, and XML/JSON schema representations.

* **Bug Fixes**
  * String datatype now preserves whitespace as documented, clarifying whitespace behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->