### PR TITLE
Add specification writing guide for contributors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,14 @@ Contains test fixtures and worked examples. Files in this directory are example 
 
 ## Key Patterns
 
+### Specification Documentation
+
+When writing or updating specification documentation, follow the [Specification Writing Guide](website/SPECIFICATION-WRITING-GUIDE.md). Key requirements:
+
+- **Deprecated features**: Show only non-deprecated values in the syntax overview (`_index.md`), but document deprecated values with clear notices in detailed documentation pages
+- **RFC 2119 keywords**: Use MUST, SHOULD, MAY consistently in uppercase
+- **Schema synchronization**: Keep `schema/json/`, `schema/xml/`, and `website/content/specification/datatypes.md` in sync
+
 ### Datatype Definitions
 When adding or modifying datatypes, update three files in sync:
 1. `schema/json/metaschema-datatypes.json` - JSON Schema definition
@@ -80,4 +88,4 @@ Constraints are documented in `website/content/specification/syntax/constraints.
 - Add a new section with syntax table and examples
 
 ## Related Repositories
-- [metaschema-java](https://github.com/metaschema-framework/metaschema-java) - Java implementation with parsing, validation, and code generation
+- [metaschema-framework/metaschema-java](https://github.com/metaschema-framework/metaschema-java) - Java implementation with parsing, validation, and code generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ This repository consists of the following directories and files pertaining to th
 - [CONTRIBUTING.md](CONTRIBUTING.md): This file is for potential contributors to the project. It provides basic information on the project, describes the main ways people can make contributions, explains how to report issues, and lists pointers to additional sources of information. It also has instructions on establishing a development environment for contributing to the project and using GitHub project cards to track development sprints.
 - [LICENSE.md](LICENSE.md): This file contains license information for the files in this GitHub repository.
 - [USERS.md](USERS.md): This file explains which types of users are most likely to benefit from use of this project and its artifacts.
+- [website/SPECIFICATION-WRITING-GUIDE.md](website/SPECIFICATION-WRITING-GUIDE.md): This file provides guidelines for contributors writing or updating the Metaschema specification documentation on the website.
 
 ## Contributing to ongoing Development
 

--- a/website/SPECIFICATION-WRITING-GUIDE.md
+++ b/website/SPECIFICATION-WRITING-GUIDE.md
@@ -1,0 +1,185 @@
+# Specification Writing Guide
+
+This guide provides patterns and best practices for contributors writing or updating the Metaschema specification documentation.
+
+## Document Structure
+
+### Quick Reference vs. Detailed Documentation
+
+The specification uses a two-tier documentation approach:
+
+1. **Quick Reference (Syntax Overview)**: The [`_index.md`](/specification/syntax/) file provides a concise syntax overview showing only the recommended, non-deprecated values and options.
+
+2. **Detailed Documentation**: Individual specification pages (e.g., `instances.md`, `definitions.md`) provide comprehensive documentation including deprecated values with clear deprecation notices.
+
+**Example**: For the `@in-xml` attribute:
+- The syntax overview shows only `WRAPPED|UNWRAPPED`
+- The detailed documentation in `instances.md` includes `WITH_WRAPPER` with a clear deprecation notice explaining it is equivalent to `WRAPPED`
+
+This pattern ensures:
+- New users see only current, recommended options in the quick reference
+- Existing implementations using deprecated values can find documentation
+- The deprecation path is clearly communicated
+
+## Handling Deprecated Features
+
+When documenting deprecated features:
+
+1. **In attribute/element tables**: List deprecated values last with "(deprecated)" notation
+   ```markdown
+   | `WRAPPED`, `UNWRAPPED`, or `WITH_WRAPPER` (deprecated) | optional | `WRAPPED` |
+   ```
+
+2. **In detailed sections**: Use a table row with bold "Deprecated" label
+   ```markdown
+   | `WITH_WRAPPER` | **Deprecated.** This value is equivalent to `WRAPPED` and SHOULD NOT be used. Use `WRAPPED` instead. |
+   ```
+
+3. **Add a callout**: Explain the deprecation context and migration path
+   ```markdown
+   {{<callout>}}
+   The `WITH_WRAPPER` value is deprecated and is retained only for backward compatibility...
+   {{</callout>}}
+   ```
+
+4. **Omit from quick reference**: Do not include deprecated values in the syntax overview (`_index.md`)
+
+## RFC 2119 Keywords
+
+Use [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) keywords consistently:
+
+- **MUST** / **MUST NOT**: Absolute requirements or prohibitions
+- **SHOULD** / **SHOULD NOT**: Strong recommendations (may be ignored with good reason)
+- **MAY**: Optional behavior
+
+Format these keywords in uppercase to distinguish them from normal prose.
+
+**Example**:
+> When the `@in-xml` attribute is not provided, the value MUST default to `WRAPPED`.
+
+## Cross-References
+
+### Internal Links
+
+Use relative links to reference other specification sections:
+
+```markdown
+See [Definition Name Resolution](/specification/syntax/module/#definition-name-resolution)
+```
+
+### Anchors
+
+When creating new sections that may be referenced:
+- Use descriptive, lowercase, hyphenated anchor names
+- Ensure anchors are stable (avoid renaming without updating all references)
+
+## Tables
+
+### Attribute Tables
+
+Use consistent column headers:
+```markdown
+| Attribute | Data Type | Use      | Default Value |
+|:---       |:---       |:---      |:---           |
+```
+
+### Element Tables
+
+Use consistent column headers:
+```markdown
+| Element | Data Type | Use      |
+|:---       |:---       |:---      |
+```
+
+### Behavior Tables
+
+For documenting enumerated values and their behaviors:
+```markdown
+| Value | Behavior |
+|:--- |:--- |
+```
+
+## Callouts
+
+Use Hugo callout shortcodes for supplementary information:
+
+```markdown
+{{<callout>}}
+Additional context or best practices that are helpful but not normative.
+{{</callout>}}
+```
+
+Reserve callouts for:
+- Best practices and recommendations
+- Clarifying context
+- Implementation notes
+- Deprecation notices
+
+## Code Examples
+
+### Metaschema XML Examples
+
+Use fenced code blocks with `xml` language and line numbers when referencing specific lines:
+
+````markdown
+```xml {linenos=table,hl_lines=[4]}
+<define-flag name="id"/>
+<define-assembly name="computer">
+  <root-name>computer</root-name>
+  <flag ref="id" required="yes"/>
+</define-assembly>
+```
+````
+
+### Multi-Format Examples
+
+When showing equivalent content in JSON, YAML, and XML, use the tabs shortcode:
+
+````markdown
+{{< tabs JSON YAML XML >}}
+{{% tab %}}
+```json
+{ "example": "value" }
+```
+{{% /tab %}}
+{{% tab %}}
+```yaml
+example: "value"
+```
+{{% /tab %}}
+{{% tab %}}
+```xml
+<example>value</example>
+```
+{{% /tab %}}
+{{< /tabs >}}
+````
+
+## TODO Markers
+
+When sections require future work, use a consistent TODO format with priority:
+
+```markdown
+TODO: P2: describe this with examples
+```
+
+Priority levels:
+- **P1**: High priority, blocks other work
+- **P2**: Medium priority, should be addressed soon
+- **P3**: Low priority, nice to have
+
+## Keeping Documentation in Sync
+
+### Schema Files
+
+When documenting data types or schema elements, ensure consistency across:
+- `schema/json/metaschema-datatypes.json` (JSON Schema definitions)
+- `schema/xml/metaschema-datatypes.xsd` (XML Schema definitions)
+- `website/content/specification/datatypes.md` (documentation)
+
+### Patterns and Descriptions
+
+When a data type has a validation pattern:
+- Document the pattern in both schema files
+- Explain the pattern's meaning in the specification
+- Ensure patterns are valid for their respective schema languages (ECMA-262 for JSON, XML Schema regex for XSD)


### PR DESCRIPTION
## Summary

- Add `website/SPECIFICATION-WRITING-GUIDE.md` documenting patterns and best practices for specification content contributors
- Update `CLAUDE.md` to reference the guide as required reading for specification documentation work
- Update `CONTRIBUTING.md` to include the guide in the repository structure section

The guide covers:
- Quick reference vs detailed documentation patterns (e.g., omit deprecated values from syntax overview, include with notices in detailed docs)
- Handling deprecated features with proper notation and callouts
- RFC 2119 keyword usage
- Cross-references and anchor conventions
- Table formatting for attributes, elements, and behaviors
- Code example formatting with Hugo shortcodes
- TODO marker conventions with priority levels
- Schema synchronization requirements

## Test plan

- [ ] Verify markdown renders correctly
- [ ] Review guide content for completeness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a new Specification Writing Guide providing comprehensive patterns, conventions, and best practices for writing specification documentation.
  * Expanded existing documentation with a new Specification Documentation subsection covering guidelines on deprecated features, RFC 2119 keywords, and maintaining synchronization across schema definitions.
  * Updated repository reference links in project documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->