### PR TITLE
Fix typo in index-has-key constraint documentation

### DIFF
--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -726,7 +726,7 @@ The `index-has-key` constraint has the same flags and assemblies as a [`index`](
 
 The `@target` flag of an `<index-has-key>` constraint defines the node(s) in a document instance to check as a cross-reference. The index MUST define a [`@target`](#target) with a [Metapath expression](/specification/syntax/metapath) to identify the nodes to check. The processor MUST only check the node(s) resulting from evaluating the `@target`.
 
-The similar to an `<index>` constraint, the `<key-field/>` assembly is used to compute the cross-reference's key.
+Similar to an `<index>` constraint, the `<key-field/>` assembly is used to compute the cross-reference's key.
 
 The `@name` flag of an `<index>` constraint MUST specify the name of a previously defined `index` constraint.
 


### PR DESCRIPTION
## Summary

- Fixed typo: "The similar to" → "Similar to" in the index-has-key constraint section

Fixes https://github.com/usnistgov/metaschema/issues/794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in the constraint specification documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->