### PR TITLE
Add qname to Metapath vs XPath comparison type list

### DIFF
--- a/website/content/specification/syntax/metapath-overview.md
+++ b/website/content/specification/syntax/metapath-overview.md
@@ -387,7 +387,7 @@ Uses XSD (XML Schema Definition) types and the XDM type hierarchy, including ato
 Uses [Metaschema data types](/specification/datatypes/), which include:
 
 **Simple types:**
-- `string`, `token`, `uri`, `uri-reference`, `uuid`
+- `string`, `token`, `qname`, `uri`, `uri-reference`, `uuid`
 - `decimal`, `integer`, `non-negative-integer`, `positive-integer`
 - `boolean`
 - `date`, `date-time`, `date-with-timezone`, `date-time-with-timezone`


### PR DESCRIPTION
## Summary

- Adds `qname` to the simple types list in Section 9 (Type System) of the Metapath vs XPath 3.1 comparison documentation

Fixes #139

## Test plan

- [x] Verify qname is listed in the type system section
- [x] Verify consistency with datatypes documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Metapath specification documentation to include `qname` as a supported simple type, expanding the available type options for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->