### PR TITLE
Fix link-check workflow permissions for reusable workflows

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: true
         type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   schedule-validate-repo-markdown-links:
     uses: ./.github/workflows/workflow-validate-repo-markdown.yml


### PR DESCRIPTION
## Summary

- Adds `permissions` block to link-check.yml granting `contents: read` and `issues: write`

## Problem

The link-check workflow calls two reusable workflows that request `issues: write` permission to create GitHub issues when broken links are detected:
- `workflow-validate-repo-markdown.yml`
- `workflow-validate-website-content.yml`

Without a top-level `permissions` block in the calling workflow, GitHub Actions defaults to restricted permissions, causing the error:

> The nested job 'validate-repo-markdown' is requesting 'issues: write', but is only allowed 'issues: none'.

## Solution

Add explicit permissions at the workflow level so the reusable workflows can inherit them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to enhance automation security permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->