### PR TITLE
fix: correct message template syntax in module constraints

### DIFF
--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -39,17 +39,17 @@
             <expect id="module-import-href-available" target="import" test="doc-available(resolve-uri(@href))">
                 <formal-name>Import is Resolvable</formal-name>
                 <description>Ensure each import has a resolvable @href.</description>
-                <message>Unable to access a Metaschema module at '{{ resolve-uri(@href) }}'.</message>
+                <message>Unable to access a Metaschema module at '{ resolve-uri(@href) }'.</message>
             </expect>
             <expect id="module-import-href-is-module" target="import" test="doc(resolve-uri(@href))/METASCHEMA ! exists(.)">
                 <formal-name>Import is a Metaschema module</formal-name>
                 <description>Ensure each import is a Metaschema module.</description>
-                <message>Unable the resource at '{{ resolve-uri(@href) }}' is not a Metaschema module.</message>
+                <message>The resource at '{ resolve-uri(@href) }' is not a Metaschema module.</message>
             </expect>
             <expect id="module-model-group-a-invalid" target=".//(define-assembly|define-field|assembly|field)[@max-occurs=1]" test=".[not(group-as)]">
                 <formal-name>Group-As unneeded with max-occurs='1'</formal-name>
                 <description>A field or assembly instance with a max occurrence of `1` must not have a `group-as` child.</description>
-                <message>Use of `group-as` in the location '{{ path() }}' requires a parent with a max-occurs that is greater than 1; otherwise the `group-as` needs to be removed.</message>
+                <message>Use of `group-as` in the location '{ path() }' requires a parent with a max-occurs that is greater than 1; otherwise the `group-as` needs to be removed.</message>
             </expect>
         </constraints>
     </context>


### PR DESCRIPTION
## Summary

- Fixes message template syntax in metaschema-module-constraints.xml from `{{ expr }}` to `{ expr }`

The double-braces were interpreted as escape sequences rather than template placeholders, causing validation messages to display the raw expression instead of the evaluated value.

## Test Plan

- [x] Build passes with corrected syntax
- [x] Message templates render correctly with single braces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message formatting in schema validation to properly resolve and display critical dynamic information, including Metaschema module access paths, resource identifiers, and constraint location details. These improvements provide clearer error reporting and help users better understand and diagnose schema validation problems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->