### PR TITLE
feat: specify any model instance and add placement constraints

### DIFF
--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -51,6 +51,18 @@
                 <description>A field or assembly instance with a max occurrence of `1` must not have a `group-as` child.</description>
                 <message>Use of `group-as` in the location '{ path() }' requires a parent with a max-occurs that is greater than 1; otherwise the `group-as` needs to be removed.</message>
             </expect>
+            <expect id="module-model-any-at-most-once" target=".//define-assembly/model"
+              test="count(any) le 1">
+                <formal-name>Any Appears At Most Once</formal-name>
+                <description>The `any` element must appear at most once in an assembly model.</description>
+                <message>The 'any' element appears more than once in the model at '{ path() }'. Only one 'any' declaration is permitted per assembly model.</message>
+            </expect>
+            <expect id="module-model-any-last" target=".//define-assembly/model/any"
+              test="empty(following-sibling::*)">
+                <formal-name>Any Appears Last in Model</formal-name>
+                <description>The `any` element must appear after all named model instances (field, define-field, assembly, define-assembly) and choice elements (choice, choice-group) in an assembly model.</description>
+                <message>The 'any' element at '{ path() }' must appear after all other model instances in the assembly model. Move the 'any' declaration to the end of the model.</message>
+            </expect>
         </constraints>
     </context>
     <context>

--- a/website/content/specification/mapping.md
+++ b/website/content/specification/mapping.md
@@ -26,6 +26,7 @@ Within Metaschema-based models, all constructs are optional unless marked otherw
 | Flag with designated data type | Attribute with lexical constraints per type | String property with lexical constraints per type, or typed property such as `number` or URI (per type) | 
 | Field `as-type='simple-markup'`, no flags permitted | An element permitting mixed content inline | String property or map with string property, parsable as markdown (line only) |
 | Field `as='complex-markup'`, flag(s) permitted | An element permitting mixed content inline | Object property with `RICHTEXT` String property or object with string property, parsable as markdown (full blocks) |
+| [`<any>`](/specification/syntax/instances/#any) in assembly model | Child elements from foreign namespaces (`xs:any namespace="##other"`) | Additional object properties not declared in the model (`additionalProperties: true`) |
 
 
 ## XML Representational Form
@@ -67,6 +68,19 @@ In XML, a field is represented in two possible ways:
 
    This form is only allowed when a field has no child flags.
 
+### `<any>` Instance
+
+When an assembly definition declares [`<any/>`](/specification/syntax/instances/#any) in its model, the XML representation permits child elements from foreign namespaces after all declared model instance elements.
+
+In a generated XML Schema, this is represented as:
+
+```xml
+<xs:any namespace="##other" processContents="lax"
+       minOccurs="0" maxOccurs="unbounded"/>
+```
+
+The `namespace="##other"` restriction limits unmodeled elements to namespaces other than the assembly's target namespace. The `processContents="lax"` setting means validation of unmodeled elements is attempted only if a schema for the element's namespace is available.
+
 ## JSON Representational Form
 
 ### Flag Instance
@@ -79,6 +93,22 @@ In JSON a flag instance is represented as an [object member](https://datatracker
 }
 ```
 
+### `<any>` Instance
+
+When an assembly definition declares [`<any/>`](/specification/syntax/instances/#any) in its model, the JSON representation permits additional properties on the assembly's object beyond those declared in the model.
+
+In a generated JSON Schema, this is represented by setting `additionalProperties` to `true` on the assembly's object schema:
+
+```json
+{
+  "type": "object",
+  "properties": { ... },
+  "additionalProperties": true
+}
+```
+
+This allows any property name and value to appear alongside the declared properties.
+
 ## YAML Representational Form
 
 ### Flag Instance
@@ -88,4 +118,8 @@ The YAML representation is similar to JSON, where a [tagged value](https://yaml.
 ```yaml
 flag-name: flag value
 ```
+
+### `<any>` Instance
+
+The YAML representation of [`<any/>`](/specification/syntax/instances/#any) is identical to the [JSON representation](#any-instance-1), since YAML is a superset of JSON. Additional mapping keys on the assembly's mapping represent unmodeled content.
 

--- a/website/content/specification/syntax/instances.md
+++ b/website/content/specification/syntax/instances.md
@@ -475,4 +475,109 @@ Permits the mutually exclusive use of a non-empty set of [named model instances]
 
 ### `<any>`
 
-TODO: P2: describe this with examples
+The `<any>` element declares that an assembly's model accepts additional content beyond what is described by the assembly's explicitly defined model instances. This is an extensibility mechanism that allows an assembly to accommodate unmodeled content — content whose structure is not described by the Metaschema module.
+
+This is analogous to [`xs:any`](https://www.w3.org/TR/xmlschema11-1/#Wildcards) in XML Schema or [`additionalProperties`](https://json-schema.org/understanding-json-schema/reference/object#additionalproperties) in JSON Schema.
+
+The `<any>` element has no attributes or child elements. It is an empty element that acts as a marker within the assembly's `<model>`.
+
+```xml
+<define-assembly name="extensible-record">
+  <formal-name>Extensible Record</formal-name>
+  <description>A record that accepts additional unmodeled content.</description>
+  <model>
+    <field ref="title" min-occurs="1"/>
+    <field ref="description"/>
+    <any/>
+  </model>
+</define-assembly>
+```
+
+#### Placement in the Model
+
+The `<any>` element MUST appear at most once in a `<model>`, and MUST appear after all [named model instances](#named-model-instances) and [`<choice>`](#choice-selections) elements.
+
+#### Semantics
+
+When `<any>` is declared in an assembly's model:
+
+- The assembly MUST accept content that does not correspond to any of its declared model instances.
+- In XML, this means child elements from foreign namespaces (i.e., namespaces other than the assembly's own namespace) MUST be accepted after all declared model elements.
+- In JSON and YAML, this means object properties whose names do not correspond to any declared model instance MUST be accepted.
+- A Metaschema-aware processor MUST capture unmodeled content during parsing and MUST reproduce it during serialization, preserving round-trip fidelity.
+- Constraint validation MUST NOT apply to unmodeled content.
+- Metapath expressions MUST NOT traverse into unmodeled content.
+
+When `<any>` is not declared, a Metaschema-aware processor SHOULD report unrecognized content through its problem-handling mechanism.
+
+#### XML Representation
+
+In XML, when an assembly with `<any>` is serialized, the unmodeled content appears as child elements after all declared model instance elements:
+
+```xml
+<extensible-record>
+  <title>My Record</title>
+  <description>An example.</description>
+  <!-- Unmodeled content below -->
+  <ext:custom-data xmlns:ext="http://example.com/extensions">
+    <ext:value>additional information</ext:value>
+  </ext:custom-data>
+</extensible-record>
+```
+
+#### JSON and YAML Representation
+
+In JSON and YAML, unmodeled content appears as additional properties on the assembly's object:
+
+{{< tabs JSON YAML >}}
+{{% tab %}}
+```json
+{
+  "extensible-record": {
+    "title": "My Record",
+    "description": "An example.",
+    "custom-data": {
+      "value": "additional information"
+    }
+  }
+}
+```
+{{% /tab %}}
+{{% tab %}}
+```yaml
+extensible-record:
+  title: My Record
+  description: An example.
+  custom-data:
+    value: additional information
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+#### Schema Generation
+
+When generating schemas from a Metaschema module containing `<any>`:
+
+- **XML Schema:** The generated schema MUST include an `xs:any` wildcard declaration after the declared element declarations within the assembly's type definition:
+
+  ```xml
+  <xs:any namespace="##other" processContents="lax"
+         minOccurs="0" maxOccurs="unbounded"/>
+  ```
+
+  The `namespace="##other"` attribute restricts unmodeled elements to namespaces other than the assembly's target namespace. The `processContents="lax"` attribute indicates that validation of unmodeled elements is attempted only if a schema for the element's namespace is available.
+
+- **JSON Schema:** The generated schema MUST set `additionalProperties` to `true` on the assembly's object schema:
+
+  ```json
+  {
+    "type": "object",
+    "additionalProperties": true
+  }
+  ```
+
+  This permits additional properties beyond those explicitly declared in the `properties` keyword.
+
+{{<callout>}}
+The `<any>` element is intended for use cases where an assembly needs to accommodate extension content whose structure is not known at module design time. Use it sparingly — prefer explicit model declarations whenever the content structure is known. Overuse of `<any>` reduces the value of schema validation and limits tooling support for the affected content.
+{{</callout>}}


### PR DESCRIPTION
## Summary

- Complete the specification documentation for the `<any/>` model instance
- Add Metaschema module constraints enforcing `<any>` placement rules

## Changes

### Documentation

- **instances.md**: Replace TODO stub with comprehensive `<any>` documentation including placement rules, semantics, XML/JSON/YAML representations, schema generation rules, and best practices
- **mapping.md**: Add `<any>` entries to format binding table and representational form sections

### Constraints

- **metaschema-module-constraints.xml**: Add two constraints:
  - `module-model-any-at-most-once`: `<any>` appears at most once per model
  - `module-model-any-last`: `<any>` appears after all named instances and choices

## Test plan

- [ ] Verify Hugo site builds with new documentation
- [ ] Verify constraint XML is well-formed
- [ ] Review constraint Metapath expressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Complete specification of the `<any>` element in assembly models with examples for XML, JSON, and YAML representations
  * Added concrete placement rules and constraints for using `<any>` within models (at most once, positioned after named instances)
  * Documented schema-generation implications across XML Schema and JSON Schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->